### PR TITLE
chores: remove withJavadocJar() to resolve duplicate javadoc.jar issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,6 @@ test {
 }
 
 java {
-    withJavadocJar()
-    withSourcesJar()
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
     }


### PR DESCRIPTION
- the vanniktech.maven.publish plugin handles generating the javadoc