### PR TITLE
feat/provide original template string

### DIFF
--- a/src/main/java/io/github/penguin418/MessageTemplate.java
+++ b/src/main/java/io/github/penguin418/MessageTemplate.java
@@ -25,6 +25,32 @@ public class MessageTemplate {
         return String.join("", resultArray);
     }
 
+    public String getTemplate() {
+        StringBuilder templateStringBuilder = new StringBuilder();
+        Map<Integer, String> indexKeywordMap = new HashMap<>();
+        for (Map.Entry<String, int[]> entry : reservedPositions.entrySet()) {
+            String keyword = entry.getKey();
+            for (int position : entry.getValue()) {
+                indexKeywordMap.put(position, keyword);
+            }
+        }
+        for (int i = 0; i < templateArray.length; i++) {
+            if (indexKeywordMap.containsKey(i)){
+                String keyword = indexKeywordMap.get(i);
+                String defaultValue = templateArray[i];
+                if (defaultValue == null) {
+                    templateStringBuilder.append("${").append(keyword).append("}");
+                } else {
+                    templateStringBuilder.append("${").append(keyword).append(":").append(defaultValue).append("}");
+                }
+            } else {
+                templateStringBuilder.append(templateArray[i]);
+            }
+        }
+        return templateStringBuilder.toString();
+    }
+
+
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/io/github/penguin418/MessageTemplate.java
+++ b/src/main/java/io/github/penguin418/MessageTemplate.java
@@ -103,6 +103,10 @@ public class MessageTemplate {
         }
 
 
+        public Builder appendTemplate(String template) {
+            return format(template, CURLY_BRACE_RESERVED_POSITION_PATTERN, CURLY_BRACE_RESERVED_POSITION_PARSER());
+        }
+
         public Builder format(String template) {
             return format(template, CURLY_BRACE_RESERVED_POSITION_PATTERN, CURLY_BRACE_RESERVED_POSITION_PARSER());
         }

--- a/src/test/java/io/github/penguin418/MessageTemplateTest.java
+++ b/src/test/java/io/github/penguin418/MessageTemplateTest.java
@@ -27,6 +27,18 @@ class MessageTemplateTest {
             assertEquals("Lorem ipsum sit amet, adipiscing elit.", st.process(Map.of()));
         }
 
+        @Test
+        void getTemplateStringTest() {
+            MessageTemplate st = MessageTemplate.builder()
+                    .append("Lorem ipsum ")
+                    .reserve("dolor", "sit")
+                    .append(" amet, ")
+                    .reserve("consectetur", "adipiscing")
+                    .append(" elit.")
+                    .build();
+            assertEquals("Lorem ipsum ${dolor:sit} amet, ${consectetur:adipiscing} elit.", st.getTemplate());
+        }
+
 
         @Test
         @DisplayName("Empty template should return an empty string")

--- a/src/test/java/io/github/penguin418/MessageTemplateTest.java
+++ b/src/test/java/io/github/penguin418/MessageTemplateTest.java
@@ -43,7 +43,7 @@ class MessageTemplateTest {
         @Test
         @DisplayName("Empty template should return an empty string")
         void staticConstructorOfTest0() {
-            MessageTemplate template = MessageTemplate.builder().format("").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("").build();
             assertEquals("", template.process(Map.of()));
         }
 
@@ -51,21 +51,21 @@ class MessageTemplateTest {
         @Test
         @DisplayName("Template with two keywords should reflect their respective values")
         void staticConstructorOfTest1() {
-            MessageTemplate template = MessageTemplate.builder().format("Lorem ${ipsum} sit ${amet}, adipiscing elit.").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("Lorem ${ipsum} sit ${amet}, adipiscing elit.").build();
             assertEquals("Lorem IPSUM sit AMET, adipiscing elit.", template.process(Map.of("ipsum", "IPSUM", "amet", "AMET")));
         }
 
         @Test
         @DisplayName("Unmatched curly braces should be ignored")
         void staticConstructorOfTest2() {
-            MessageTemplate template = MessageTemplate.builder().format("Lorem {${ipsum} sit ${amet}}, adipiscing elit.").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("Lorem {${ipsum} sit ${amet}}, adipiscing elit.").build();
             assertEquals("Lorem {IPSUM sit AMET}, adipiscing elit.", template.process(Map.of("ipsum", "IPSUM", "amet", "AMET")));
         }
 
         @Test
         @DisplayName("Nested curly brace should be captured as reserved keyword")
         void staticConstructorOfTest3() {
-            MessageTemplate template = MessageTemplate.builder().format("Lorem {${ipsum}} sit ${ipsum}, adipiscing elit.").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("Lorem {${ipsum}} sit ${ipsum}, adipiscing elit.").build();
             assertEquals("Lorem {IPSUM} sit IPSUM, adipiscing elit.", template.process(Map.of("ipsum", "IPSUM")));
         }
 
@@ -73,28 +73,28 @@ class MessageTemplateTest {
         @Test
         @DisplayName("Curly braces should capture all character before closing")
         void staticConstructorOfTest4() {
-            MessageTemplate template = MessageTemplate.builder().format("Lorem ${{ipsum} sit ${amet}, adipiscing elit.").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("Lorem ${{ipsum} sit ${amet}, adipiscing elit.").build();
             assertEquals("Lorem IPSUM sit null, adipiscing elit.", template.process(Map.of("{ipsum", "IPSUM")));
         }
 
         @Test
         @DisplayName("Escaped special character should be ignored")
         void staticConstructorOfTestEscapeSpecialCharacters() {
-            MessageTemplate template = MessageTemplate.builder().format("Lorem \\${ipsum} sit $\\${amet}, adipiscing $${elit}.").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("Lorem \\${ipsum} sit $\\${amet}, adipiscing $${elit}.").build();
             assertEquals("Lorem \\${ipsum} sit $\\${amet}, adipiscing $100.", template.process(Map.of("elit", "100")));
         }
 
         @Test
         @DisplayName("Default value should be used")
         void staticConstructorOfTestDefaultValue() {
-            MessageTemplate template = MessageTemplate.builder().format("Lorem ${ipsum:DEFAULT1} sit ${amet:DEFAULT2}, adipiscing elit.").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("Lorem ${ipsum:DEFAULT1} sit ${amet:DEFAULT2}, adipiscing elit.").build();
             assertEquals("Lorem DEFAULT1 sit DEFAULT2, adipiscing elit.", template.process(Map.of()));
         }
 
         @Test
         @DisplayName("Duplicated keyword should hold respective default value")
         void staticConstructorOfTestDuplicateKeyword() {
-            MessageTemplate template = MessageTemplate.builder().format("Lorem ${ipsum:DEFAULT1} sit ${ipsum:DEFAULT2}, adipiscing elit.").build();
+            MessageTemplate template = MessageTemplate.builder().appendTemplate("Lorem ${ipsum:DEFAULT1} sit ${ipsum:DEFAULT2}, adipiscing elit.").build();
             assertEquals("Lorem DEFAULT1 sit DEFAULT2, adipiscing elit.", template.process(Map.of()));
             assertEquals("Lorem IPSUM sit IPSUM, adipiscing elit.", template.process(Map.of("ipsum", "IPSUM")));
         }


### PR DESCRIPTION
add getTemplate() method providing original template string for reuse
- the original template string can be used as an argument for the Builder's appendTemplate(String) method

add appendTemplate(String) to Builder to replace format(String)