### PR TITLE
refactor/encapsulate message template

### DIFF
--- a/src/main/java/io/github/penguin418/MessageTemplate.java
+++ b/src/main/java/io/github/penguin418/MessageTemplate.java
@@ -29,16 +29,6 @@ public class MessageTemplate {
         return new Builder();
     }
 
-    public static class ReservedPosition {
-        String keyword;
-        String defaultValue;
-
-        public ReservedPosition(String keyword, String defaultValue) {
-            this.keyword = keyword;
-            this.defaultValue = defaultValue;
-        }
-    }
-
     public static class Builder {
         public static Pattern CURLY_BRACE_RESERVED_POSITION_PATTERN = Pattern.compile("(?<!\\\\)\\$\\{([^}]*)}");
 
@@ -105,6 +95,16 @@ public class MessageTemplate {
             }
 
             return new MessageTemplate(templateList.toArray(new String[0]), reservedPositions);
+        }
+
+        private static class ReservedPosition {
+            String keyword;
+            String defaultValue;
+
+            public ReservedPosition(String keyword, String defaultValue) {
+                this.keyword = keyword;
+                this.defaultValue = defaultValue;
+            }
         }
     }
 }

--- a/src/main/java/io/github/penguin418/MessageTemplate.java
+++ b/src/main/java/io/github/penguin418/MessageTemplate.java
@@ -76,7 +76,7 @@ public class MessageTemplate {
             return this;
         }
 
-
+        @Deprecated
         public Builder format(String template) {
             return format(template, CURLY_BRACE_RESERVED_POSITION_PATTERN, CURLY_BRACE_RESERVED_POSITION_PARSER());
         }

--- a/src/main/java/io/github/penguin418/MessageTemplate.java
+++ b/src/main/java/io/github/penguin418/MessageTemplate.java
@@ -131,7 +131,7 @@ public class MessageTemplate {
             String keyword;
             String defaultValue;
 
-            public ReservedPosition(String keyword, String defaultValue) {
+            private ReservedPosition(String keyword, String defaultValue) {
                 this.keyword = keyword;
                 this.defaultValue = defaultValue;
             }


### PR DESCRIPTION
deprecate Builder's format method.
moved the ReservedPosition inner class inside the Builder class to encapsulate it within the builder's scope